### PR TITLE
Add API routes for drawing flows

### DIFF
--- a/data/flow-types.json
+++ b/data/flow-types.json
@@ -1,0 +1,24 @@
+{
+  "flowTypes": [
+    {
+      "id": "grain",
+      "name": "Grain"
+    },
+    {
+      "id": "nuts",
+      "name": "Nuts"
+    },
+    {
+      "id": "vegetables",
+      "name": "Vegetables"
+    },
+    {
+      "id": "fruits",
+      "name": "Fruits"
+    },
+    {
+      "id": "tubbers",
+      "name": "Tubers"
+    }
+  ]
+}

--- a/migrations/20230427103535_add-counties.js
+++ b/migrations/20230427103535_add-counties.js
@@ -16,8 +16,8 @@ const COUNTIES_GEOJSON_PATH = path.join(
  */
 exports.up = async function (knex) {
   await knex.schema.createTable("counties", (table) => {
-    table.string("id").primary();
-    table.jsonb("meta");
+    table.integer("id").primary();
+    table.jsonb("properties");
     table.geography("geom", "4326");
   });
 
@@ -28,7 +28,7 @@ exports.up = async function (knex) {
   await knex("counties").insert(
     counties.map((county) => ({
       id: county.properties.geoid,
-      meta: county.properties,
+      properties: county.properties,
       geom: postgis(knex).geomFromGeoJSON(county.geometry),
     }))
   );

--- a/migrations/20230508101546_add-flow-types.js
+++ b/migrations/20230508101546_add-flow-types.js
@@ -1,0 +1,35 @@
+const path = require("path");
+const fs = require("fs-extra");
+
+const BASE_PATH = path.resolve();
+const COUNTIES_GEOJSON_PATH = path.join(BASE_PATH, "data", "flow-types.json");
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  await knex.schema.createTable("flow_types", (table) => {
+    table.string("id").primary();
+    table.string("name");
+  });
+
+  // Load GeoJSON file
+  const { flowTypes } = await fs.readJSON(COUNTIES_GEOJSON_PATH);
+
+  // Batch insert counties
+  await knex("flow_types").insert(
+    flowTypes.map(({ id, name }) => ({
+      id,
+      name,
+    }))
+  );
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex.schema.dropTable("flow_types");
+};

--- a/package.json
+++ b/package.json
@@ -31,16 +31,17 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-map-gl": "^7.0.23",
-    "swagger-ui-react": "^4.18.3",
-    "typescript": "5.0.4",
     "react-select": "^5.7.3",
+    "swagger-ui-react": "^4.18.3",
     "topojson-client": "^3.1.0",
-    "turf": "^3.0.14"
+    "turf": "^3.0.14",
+    "typescript": "5.0.4",
+    "yup": "^1.1.1"
   },
   "devDependencies": {
     "@apidevtools/swagger-cli": "^4.0.4",
     "@types/geojson": "^7946.0.10",
-    "@types/turf": "^3.5.32",
-    "@types/papaparse": "^5.3.7"
+    "@types/papaparse": "^5.3.7",
+    "@types/turf": "^3.5.32"
   }
 }

--- a/src/pages/api/county/[countyId].js
+++ b/src/pages/api/county/[countyId].js
@@ -22,9 +22,9 @@ export default async function handler(req, res) {
 
   // Query county
   const county = await db("counties")
-    .select("id", "meta")
+    .select("id", "properties")
     .where("id", countyId)
     .first();
 
-  return res.status(200).json({ county: { id: county.id, ...county.meta } });
+  return res.status(200).json({ ...county });
 }

--- a/src/pages/api/county/[countyId]/inbound.js
+++ b/src/pages/api/county/[countyId]/inbound.js
@@ -1,0 +1,46 @@
+const db = require("../../../../helpers/db");
+
+export default async function handler(req, res) {
+  const { countyId } = req.query;
+
+  // Get target county
+  const county = await db("counties")
+    .select(
+      "id",
+      db.raw("properties->>'name' as name"),
+      db.raw("ST_AsGeoJSON(ST_Centroid(geom)) as centroid")
+    )
+    .where("id", countyId)
+    .first();
+
+  // Get inbound counties
+  const inboundCounties = await db("counties")
+    .select(
+      "id",
+      db.raw("properties->>'name' as name"),
+      db.raw("ST_AsGeoJSON(ST_Centroid(geom)) as centroid")
+    )
+    .orderByRaw("random()")
+    .limit(5);
+
+  // Get flow types
+  const flowTypes = await db("flow_types").select("id");
+
+  // Generate randomized flows
+  const flows = {
+    county: {
+      ...county,
+      centroid: JSON.parse(county.centroid),
+    },
+    inbound: [...inboundCounties].map((county) => ({
+      ...county,
+      centroid: JSON.parse(county.centroid),
+      flows: flowTypes.reduce((acc, { id }) => {
+        acc[id] = Math.random() * 1000;
+        return acc;
+      }, {}),
+    })),
+  };
+
+  return res.status(200).json({ flows });
+}

--- a/src/pages/api/county/[countyId]/index.js
+++ b/src/pages/api/county/[countyId]/index.js
@@ -1,4 +1,4 @@
-const db = require("../../../helpers/db");
+const db = require("../../../../helpers/db");
 
 /**
  * @swagger

--- a/src/pages/api/county/[countyId]/routes.js
+++ b/src/pages/api/county/[countyId]/routes.js
@@ -1,0 +1,68 @@
+import * as Yup from "yup";
+import db from "../../../../helpers/db";
+
+const validationSchema = Yup.object({
+  countyId: Yup.number().required().positive().integer().required(),
+  to: Yup.string()
+    .test(
+      "is-array-of-integers",
+      "must be an array of integers separated by comma",
+      (value) => {
+        if (!value) return true;
+        const regex = /^\d+(,\d+)*$/;
+        return regex.test(value);
+      }
+    )
+    .required(),
+});
+
+async function handler(req, res) {
+  const { countyId, to } = await validationSchema.validate(req.query);
+
+  // Get target county
+  const origin = await db("counties")
+    .select(
+      "id",
+      db.raw("properties->>'name' as name"),
+      db.raw("ST_AsGeoJSON(ST_Centroid(geom)) as centroid")
+    )
+    .where("id", countyId)
+    .first()
+    .then((county) => ({
+      ...county,
+      centroid: JSON.parse(county.centroid),
+    }));
+
+  const destinations = await db("counties")
+    .select(
+      "id",
+      db.raw("properties->>'name' as name"),
+      db.raw("ST_AsGeoJSON(ST_Centroid(geom)) as centroid")
+    )
+    .whereIn("id", to.split(","))
+    .then((counties) =>
+      counties.map((county) => ({
+        ...county,
+        centroid: JSON.parse(county.centroid),
+      }))
+    );
+
+  const routes = {
+    type: "FeatureCollection",
+    features: destinations.map((d) => ({
+      type: "Feature",
+      properties: {
+        originId: origin.id,
+        destinationId: d.id,
+      },
+      geometry: {
+        coordinates: [origin.centroid.coordinates, d.centroid.coordinates],
+        type: "LineString",
+      },
+    })),
+  };
+
+  return res.json({ routes });
+}
+
+export default handler;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5350,6 +5350,11 @@ prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+property-expr@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.5.tgz#278bdb15308ae16af3e3b9640024524f4dc02cb4"
+  integrity sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==
+
 property-information@^5.0.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.6.0.tgz#61675545fb23002f245c6540ec46077d4da3ed69"
@@ -6286,6 +6291,11 @@ tilebelt@^1.0.1:
   resolved "https://registry.yarnpkg.com/tilebelt/-/tilebelt-1.0.1.tgz#3bbf7113b3fec468efb0d9148f4bb71ef126a21a"
   integrity sha512-cxHzpa5JgsugY9NUVRH43gPaGJw/29LecAn4X7UGOP64+kB8pU4VQ3bIhSyfb5Mk4jDxwl3yk330L/EIhbJ5aw==
 
+tiny-case@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-case/-/tiny-case-1.0.3.tgz#d980d66bc72b5d5a9ca86fb7c9ffdb9c898ddd03"
+  integrity sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==
+
 tiny-glob@^0.2.9:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/tiny-glob/-/tiny-glob-0.2.9.tgz#2212d441ac17928033b110f8b3640683129d31e2"
@@ -6336,6 +6346,11 @@ topojson-server@3.x:
   integrity sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==
   dependencies:
     commander "2"
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -6874,6 +6889,11 @@ type-fest@^1.2.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
   integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
+type-fest@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
+
 type-flag@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/type-flag/-/type-flag-2.2.0.tgz#56ed3a79a3011bafba3ceb9d1a5acb633ade7884"
@@ -7149,6 +7169,16 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yup@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-1.1.1.tgz#49dbcf5ae7693ed0a36ed08a9e9de0a09ac18e6b"
+  integrity sha512-KfCGHdAErqFZWA5tZf7upSUnGKuTOnsI3hUsLr7fgVtx+DK04NPV01A68/FslI4t3s/ZWpvXJmgXhd7q6ICnag==
+  dependencies:
+    property-expr "^2.0.5"
+    tiny-case "^1.0.3"
+    toposort "^2.0.2"
+    type-fest "^2.19.0"
 
 z-schema@^4.2.3:
   version "4.2.4"


### PR DESCRIPTION
This PR aims to introduce an initial implementation of the API routes necessary for rendering flow maps. This work is currently in progress. The following changes have been made:

- Added a flow types table and corresponding seed data
- Modified the counties table migration to utilize integer IDs
- Implemented the /county/:id/inbound route, which will return randomized inbound flows until the final data is available
- Created the /county/:id/routes route, which returns a FeatureCollection of LineStrings from the origin county to the destination counties specified by the `to=` parameter

To test at this stage:

1. Roll back all migrations and execute `yarn migrate` (I chose not to add a new migration to avoid typecasting the entire counties table, as there is no production database yet)
2. Access the following routes:
   - http://localhost:3000/api/county/1001
   - http://localhost:3000/api/county/1001/inbound
   - http://localhost:3000/api/county/1001/routes?to=01005,01007

@nerik, note that this implementation may change once the final data is available. Please let me know if you notice any issues or have suggestions at this time.