### PR TITLE
Connect API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Migrate the database:
 yarn migrate
 ```
 
-Download [seed data](https://drive.google.com/file/d/10DsMpXzoqaF9sWhSentwO5ReZSCrPPA9/view?usp=sharing) and expand it in the root folder the cloned repository. The contents of the zip file should be located at `./app-data`.
+Download the contents of this [Google Drive folder](https://drive.google.com/drive/folders/1uDlDT7NNI7l5WC0A9WsAZTlFWpC0Uo1i?usp=sharing) and add it to a directory called `./app-data` in the cloned repository.
 
 Ingest downloaded data with:
 

--- a/migrations/20230508101546_add-crops.js
+++ b/migrations/20230508101546_add-crops.js
@@ -6,7 +6,7 @@ exports.up = async function (knex) {
   await knex.schema.createTable("crops", (table) => {
     table.integer("id").primary();
     table.string("name");
-    table.jsonb("meta");
+    table.string("category");
   });
 };
 

--- a/seeds/001-add-counties.js
+++ b/seeds/001-add-counties.js
@@ -3,10 +3,10 @@ const fs = require("fs-extra");
 const postgis = require("knex-postgis");
 const { APP_DATA_DIR } = require("../config");
 
-// Generate absolute paths to the GeoJSON file in the local filesystem
-const COUNTIES_GEOJSON_PATH = path.join(
+// Generate absolute paths to the input file
+const COUNTIES_FILE_PATH = path.join(
   APP_DATA_DIR,
-  "population_counties_conus.geojson"
+  "county-population-consumption-production-scaled.geojson"
 );
 
 exports.seed = async function (knex) {
@@ -16,12 +16,12 @@ exports.seed = async function (knex) {
   await knex("counties").del();
 
   // Load GeoJSON file
-  const { features: counties } = await fs.readJSON(COUNTIES_GEOJSON_PATH);
+  const { features: counties } = await fs.readJson(COUNTIES_FILE_PATH);
 
   // Batch insert counties
   await knex("counties").insert(
     counties.map((county) => ({
-      id: county.properties.geoid,
+      id: county.properties.geography.slice(-5),
       properties: county.properties,
       geom: postgis(knex).geomFromGeoJSON(county.geometry),
     }))

--- a/seeds/002-add-crops.js
+++ b/seeds/002-add-crops.js
@@ -2,7 +2,7 @@ const path = require("path");
 const fs = require("fs-extra");
 const { APP_DATA_DIR } = require("../config");
 
-const CROPS_CSV_PATH = path.join(APP_DATA_DIR, "cdl-codes.csv");
+const CROPS_CSV_PATH = path.join(APP_DATA_DIR, "crops.csv");
 
 exports.seed = async function (knex) {
   const cropCodes = await fs.readFile(CROPS_CSV_PATH, "utf-8");
@@ -17,29 +17,11 @@ exports.seed = async function (knex) {
   await knex("crops").insert(
     rows
       .map((row) => {
-        const [
-          id,
-          crop_code,
-          name,
-          Erdas_Red,
-          Erdas_Green,
-          Erdas_Blue,
-          ESRI_Red,
-          ESRI_Green,
-          ESRI_Blue,
-        ] = row.split(",");
+        const [id, name, category] = row.split(",");
         return {
           id,
           name: name.trim(),
-          meta: {
-            crop_code,
-            Erdas_Red: parseFloat(Erdas_Red),
-            Erdas_Green: parseFloat(Erdas_Green),
-            Erdas_Blue: parseFloat(Erdas_Blue),
-            ESRI_Red: parseFloat(ESRI_Red),
-            ESRI_Green: parseFloat(ESRI_Green),
-            ESRI_Blue: parseFloat(ESRI_Blue),
-          },
+          category,
         };
       })
       .filter((row) => row.name !== "")

--- a/seeds/003-add-kcal-flows.js
+++ b/seeds/003-add-kcal-flows.js
@@ -10,7 +10,14 @@ exports.seed = async function (knex) {
 
   for (const file of files) {
     // Extract id from filename
-    const crop_id = file.split("_")[3];
+    const crop_name = file
+      .replace("kcal_produced_", "")
+      .replace("_results_df.csv", "");
+
+    const { id: crop_id } = await knex("crops")
+      .where("name", crop_name)
+      .select("id")
+      .first();
 
     // Load CSV file
     const kcalFlows = await fs.readFile(
@@ -20,7 +27,7 @@ exports.seed = async function (knex) {
     console.log(`Ingesting ${path.join(KCAL_FLOWS_DIR, file)}`);
 
     // Split CSV into rows
-    const rows = kcalFlows.split("\n");
+    const rows = kcalFlows.split("\n").filter((row) => row !== "");
 
     // Remove header row
     rows.shift();
@@ -30,7 +37,13 @@ exports.seed = async function (knex) {
       await knex("kcal_flows").insert(
         rows
           .map((row) => {
-            const [_, origin_id, destination_id, value] = row.split(",");
+            const [origin_id, destination_id, value] = row.split(",");
+
+            if (!origin_id || !destination_id || !value) {
+              console.log("Skipping row", row);
+              return null;
+            }
+
             return {
               origin_id,
               destination_id,
@@ -41,7 +54,8 @@ exports.seed = async function (knex) {
           .filter((row) => row.origin_id !== "Dade")
       );
     } catch (error) {
-      console.log(error?.detail);
+      console.log(error);
+      return;
     }
   }
 };

--- a/src/hooks/useFlows.ts
+++ b/src/hooks/useFlows.ts
@@ -32,7 +32,6 @@ export default function useFlows(): Flow[] {
     `/api/county/${selectedCounty?.properties.geoid}/inbound`,
     fetcher
   );
-  console.log(flowsData)
 
   return useMemo(() => {
     if (!selectedCounty || !counties || !flowsData) return [];

--- a/src/hooks/useFlows.ts
+++ b/src/hooks/useFlows.ts
@@ -5,7 +5,7 @@ import {
   FlowWithPaths,
   FlowWithTrips,
   Path,
-  RawFlow,
+  RawCountyWithFlows,
   RawFlows,
   Trip,
 } from "@/types";
@@ -40,7 +40,7 @@ export default function useFlows(): Flow[] {
     const centerCentroid = centroid(selectedCounty);
     const { inbound } = flowsData;
     let selectedLinks: Flow[] = inbound.map(
-      ({ county_id, county_centroid }: RawFlow) => {
+      ({ county_id, county_centroid }: RawCountyWithFlows) => {
         const value = Math.floor(Math.random() * 100);
         // const VALUES_RATIOS_BY_FOOD_GROUP = [.1,.2,.3,.35,1]
         // const VALUES_RATIOS_BY_FOOD_GROUP = [.2,.4,.6,.8,1]

--- a/src/hooks/useFlows.ts
+++ b/src/hooks/useFlows.ts
@@ -5,7 +5,7 @@ import {
   FlowWithPaths,
   FlowWithTrips,
   Path,
-  RawCountyWithFlows,
+  RawFlow,
   RawFlows,
   Trip,
 } from "@/types";
@@ -17,6 +17,7 @@ import { countiesAtom, flowTypeAtom } from "@/atoms";
 import useSelectedCounty from "./useSelectedCounty";
 import { useControls } from "leva";
 import useSWR from "swr";
+import { centroid } from "turf";
 
 export default function useFlows(): Flow[] {
   const counties = useAtomValue(countiesAtom);
@@ -31,13 +32,15 @@ export default function useFlows(): Flow[] {
     `/api/county/${selectedCounty?.properties.geoid}/inbound`,
     fetcher
   );
+  console.log(flowsData)
 
   return useMemo(() => {
     if (!selectedCounty || !counties || !flowsData) return [];
-    const { inbound, county } = flowsData.flows;
-
+    const { geoid: centerId } = selectedCounty.properties;
+    const centerCentroid = centroid(selectedCounty);
+    const { inbound } = flowsData;
     let selectedLinks: Flow[] = inbound.map(
-      ({ id, centroid, flows }: RawCountyWithFlows) => {
+      ({ county_id, county_centroid }: RawFlow) => {
         const value = Math.floor(Math.random() * 100);
         // const VALUES_RATIOS_BY_FOOD_GROUP = [.1,.2,.3,.35,1]
         // const VALUES_RATIOS_BY_FOOD_GROUP = [.2,.4,.6,.8,1]
@@ -46,16 +49,16 @@ export default function useFlows(): Flow[] {
         return {
           source:
             flowType === "consumer"
-              ? centroid.coordinates
-              : county.centroid.coordinates,
+              ? county_centroid.coordinates
+              : centerCentroid.geometry.coordinates,
           target:
             flowType === "consumer"
-              ? county.centroid.coordinates
-              : centroid.coordinates,
+              ? centerCentroid.geometry.coordinates
+              : county_centroid.coordinates,
           sourceId:
-            flowType === "consumer" ? id.toString() : county.id.toString(),
+            flowType === "consumer" ? county_id : centerId.toString(),
           targetId:
-            flowType === "consumer" ? county.id.toString() : id.toString(),
+            flowType === "consumer" ? centerId.toString() : county_id,
           value,
           valuesRatiosByFoodGroup: VALUES_RATIOS_BY_FOOD_GROUP,
         };

--- a/src/pages/api/county/[countyId]/inbound.js
+++ b/src/pages/api/county/[countyId]/inbound.js
@@ -1,3 +1,5 @@
+import { groupFlowsByCounty } from "./util";
+
 const db = require("../../../../helpers/db");
 
 export default async function handler(req, res) {
@@ -20,7 +22,7 @@ export default async function handler(req, res) {
     .orderBy("kcal_flows.value", "desc");
 
   return res.status(200).json({
-    inbound: inbound.map((f) => ({
+    inbound: groupFlowsByCounty(inbound).map((f) => ({
       ...f,
       county_centroid: JSON.parse(f.county_centroid),
     })),

--- a/src/pages/api/county/[countyId]/inbound.js
+++ b/src/pages/api/county/[countyId]/inbound.js
@@ -1,4 +1,4 @@
-import { groupFlowsByCounty } from "./util";
+import { getStats, groupFlowsByCounty } from "./util";
 
 const db = require("../../../../helpers/db");
 
@@ -26,5 +26,6 @@ export default async function handler(req, res) {
       ...f,
       county_centroid: JSON.parse(f.county_centroid),
     })),
+    stats: getStats(inbound),
   });
 }

--- a/src/pages/api/county/[countyId]/index.js
+++ b/src/pages/api/county/[countyId]/index.js
@@ -22,9 +22,15 @@ export default async function handler(req, res) {
 
   // Query county
   const county = await db("counties")
-    .select("id", "properties")
+    .select(
+      "id",
+      "properties",
+      db.raw("ST_AsGeoJSON(ST_Centroid(geom)) as centroid")
+    )
     .where("id", countyId)
     .first();
 
-  return res.status(200).json({ ...county });
+  return res
+    .status(200)
+    .json({ ...county, centroid: JSON.parse(county.centroid) });
 }

--- a/src/pages/api/county/[countyId]/outbound.js
+++ b/src/pages/api/county/[countyId]/outbound.js
@@ -1,3 +1,5 @@
+import { groupFlowsByCounty } from "./util";
+
 const db = require("../../../../helpers/db");
 
 export default async function handler(req, res) {
@@ -20,7 +22,7 @@ export default async function handler(req, res) {
     .orderBy("kcal_flows.value", "desc");
 
   return res.status(200).json({
-    outbound: outbound.map((f) => ({
+    outbound: groupFlowsByCounty(outbound).map((f) => ({
       ...f,
       county_centroid: JSON.parse(f.county_centroid),
     })),

--- a/src/pages/api/county/[countyId]/outbound.js
+++ b/src/pages/api/county/[countyId]/outbound.js
@@ -4,9 +4,9 @@ export default async function handler(req, res) {
   const { countyId } = req.query;
 
   // Get inbound kcal flows for target county
-  const inbound = await db("kcal_flows")
+  const outbound = await db("kcal_flows")
     .select(
-      "kcal_flows.origin_id as county_id",
+      "kcal_flows.destination_id as county_id",
       db.raw("counties.properties->>'name' as county_name"),
       db.raw("ST_AsGeoJSON(ST_Centroid(counties.geom)) as county_centroid"),
       "kcal_flows.crop_id as crop_id",
@@ -14,13 +14,13 @@ export default async function handler(req, res) {
       "crops.category as crop_category",
       "kcal_flows.value"
     )
-    .where("kcal_flows.destination_id", countyId)
-    .join("counties", "kcal_flows.origin_id", "=", "counties.id")
+    .where("kcal_flows.origin_id", countyId)
+    .join("counties", "kcal_flows.destination_id", "=", "counties.id")
     .join("crops", "kcal_flows.crop_id", "=", "crops.id")
     .orderBy("kcal_flows.value", "desc");
 
   return res.status(200).json({
-    inbound: inbound.map((f) => ({
+    outbound: outbound.map((f) => ({
       ...f,
       county_centroid: JSON.parse(f.county_centroid),
     })),

--- a/src/pages/api/county/[countyId]/outbound.js
+++ b/src/pages/api/county/[countyId]/outbound.js
@@ -26,5 +26,6 @@ export default async function handler(req, res) {
       ...f,
       county_centroid: JSON.parse(f.county_centroid),
     })),
+    stats: getStats(inbound),
   });
 }

--- a/src/pages/api/county/[countyId]/util.js
+++ b/src/pages/api/county/[countyId]/util.js
@@ -1,0 +1,28 @@
+export function groupFlowsByCounty(rawFlows) {
+  return rawFlows.reduce((acc, curr) => {
+    const existing = acc.find((f) => f.county_id === curr.county_id);
+    if (existing) {
+      existing.flows.push({
+        crop_id: curr.crop_id,
+        crop_name: curr.crop_name,
+        crop_category: curr.crop_category,
+        value: curr.value,
+      });
+    } else {
+      acc.push({
+        county_id: curr.county_id,
+        county_name: curr.county_name,
+        county_centroid: curr.county_centroid,
+        flows: [
+          {
+            crop_id: curr.crop_id,
+            crop_name: curr.crop_name,
+            crop_category: curr.crop_category,
+            value: curr.value,
+          },
+        ],
+      });
+    }
+    return acc;
+  }, []);
+}

--- a/src/pages/api/county/[countyId]/util.js
+++ b/src/pages/api/county/[countyId]/util.js
@@ -43,3 +43,40 @@ export function groupFlowsByCounty(rawFlows) {
 
   return flowsByCounty;
 }
+
+export function getStats(flows) {
+  const stats = {
+    byCrop: {},
+    byCropGroup: {}
+  }
+
+  stats.byCrop = flows.reduce((acc, curr) => {
+    const existing = acc.find((f) => f.crop_id === curr.crop_id);
+    if (existing) {
+      existing.value += curr.value;
+    } else {
+      acc.push({
+        crop_id: curr.crop_id,
+        crop_name: curr.crop_name,
+        crop_category: curr.crop_category,
+        value: curr.value,
+      });
+    }
+    return acc;
+  }, []);
+
+  stats.byCropGroup = stats.byCrop.reduce((acc, curr) => {
+    const existing = acc.find((c) => c.crop_category === curr.crop_category);
+    if (existing) {
+      existing.value += curr.value;
+    } else {
+      acc.push({
+        crop_category: curr.crop_category,
+        value: curr.value,
+      });
+    }
+    return acc;
+  }, []);
+
+  return stats;
+}

--- a/src/pages/api/county/[countyId]/util.js
+++ b/src/pages/api/county/[countyId]/util.js
@@ -1,8 +1,8 @@
 export function groupFlowsByCounty(rawFlows) {
-  return rawFlows.reduce((acc, curr) => {
+  const flowsByCounty = rawFlows.reduce((acc, curr) => {
     const existing = acc.find((f) => f.county_id === curr.county_id);
     if (existing) {
-      existing.flows.push({
+      existing.flowsByCrop.push({
         crop_id: curr.crop_id,
         crop_name: curr.crop_name,
         crop_category: curr.crop_category,
@@ -13,7 +13,7 @@ export function groupFlowsByCounty(rawFlows) {
         county_id: curr.county_id,
         county_name: curr.county_name,
         county_centroid: curr.county_centroid,
-        flows: [
+        flowsByCrop: [
           {
             crop_id: curr.crop_id,
             crop_name: curr.crop_name,
@@ -25,4 +25,21 @@ export function groupFlowsByCounty(rawFlows) {
     }
     return acc;
   }, []);
+
+  flowsByCounty.forEach((f) => {
+    f.flowsByCropGroup = f.flowsByCrop.reduce((acc, curr) => {
+      const existing = acc.find((c) => c.crop_category === curr.crop_category);
+      if (existing) {
+        existing.value += curr.value;
+      } else {
+        acc.push({
+          crop_category: curr.crop_category,
+          value: curr.value,
+        });
+      }
+      return acc;
+    }, []);
+  });
+
+  return flowsByCounty;
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -11,8 +11,8 @@ export type County = {
 export type Category = "vegetables" | "nuts" | "grain" | "fruits" | "tubbers";
 
 export type RawCountyFlows = {
-  crop_id: number;
-  crop_name: string;
+  crop_id?: number;
+  crop_name?: string;
   crop_category: Category,
   value: number,
 }
@@ -21,7 +21,8 @@ export type RawCountyWithFlows = {
   county_id: string;
   county_name: string;
   county_centroid: Geometry<Point>;
-  flows: RawCountyFlows[];
+  flowsByCrop: RawCountyFlows[];
+  flowsByCropGroup: RawCountyFlows[];
 };
 
 export type RawFlows = {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -10,17 +10,22 @@ export type County = {
 
 export type Category = "vegetables" | "nuts" | "grain" | "fruits" | "tubbers";
 
-export type RawFlow = { 
+export type RawCountyFlows = {
+  crop_id: number;
+  crop_name: string;
+  crop_category: Category,
+  value: number,
+}
+  
+export type RawCountyWithFlows = { 
   county_id: string;
   county_name: string;
   county_centroid: Geometry<Point>;
-  crop_id: number;
-  crop_name: string;
-  value: number;
+  flows: RawCountyFlows[];
 };
 
 export type RawFlows = {
-  inbound: RawFlow[];
+  inbound: RawCountyWithFlows[];
 };
 
 export type Flow = {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -10,21 +10,17 @@ export type County = {
 
 export type Category = "vegetables" | "nuts" | "grain" | "fruits" | "tubbers";
 
-export type RawCounty = {
-  id: number;
-  name: string;
-  centroid: Geometry<Point>;
-};
-
-export type RawCountyWithFlows = RawCounty & {
-  flows: Record<Category, number>;
+export type RawFlow = { 
+  county_id: string;
+  county_name: string;
+  county_centroid: Geometry<Point>;
+  crop_id: number;
+  crop_name: string;
+  value: number;
 };
 
 export type RawFlows = {
-  flows: {
-    county: RawCounty;
-    inbound: RawCountyWithFlows[];
-  };
+  inbound: RawFlow[];
 };
 
 export type Flow = {


### PR DESCRIPTION
This connects the remaining API routes. Contributes to #6.

Changes introduced:

- Updated data package hosted in Google Drive with final data
- Added `category` to crops table
- Updated workflow to reflect changes in the final data
- Use `county.properties.geography` instead `county.properties.geoid` to get the county id because the first is a string
- Route `country/:id/inbound` and `county/:id/outbound` are now fetching data from the database
- Added centroid to the response payload of `country/:id`

I've changed the response format for `inbound` and `outbound` routes. The frontend will probably fetch population, centroid and other metadata from `country/:id`, so it looked unnecessary to return the target country in addition to the list of flows. 

How to test this:

- Update .env file to point to local DB
- Rollback existing migrations with `./node_modules/.bin/knex migrate:rollback`
- Migrate with `yarn migrate`
- Ingest seed data with `yarn seed`
- Run the server
- Access example routes:
  - http://localhost:3000/api/county/54003/outbound
  - http://localhost:3000/api/county/47173/inbound

@nerik this is ready for a first review. 