### PR TITLE
Enable Plausible analytics

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 DATABASE_URL=postgres://postgres:postgres@localhost:5433/food-twin?sslmode=disable
 NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=
+#NEXT_PUBLIC_PLAUSIBLE_DOMAIN=<Website domain for Plausible analytics>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -90,7 +90,7 @@ function Home({
         {process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN && (
           <script
             defer
-            data-domain={process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN || ""}
+            data-domain={process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN}
             src="https://plausible.io/js/script.js"
           ></script>
         )}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -87,6 +87,13 @@ function Home({
           href="/favicon-16x16.png"
         />
         <link rel="manifest" href="/site.webmanifest" />
+        {process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN && (
+          <script
+            defer
+            data-domain={process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN || ""}
+            src="https://plausible.io/js/script.js"
+          ></script>
+        )}
       </Head>
 
       <MapProvider>


### PR DESCRIPTION
This adds the <script> tag to start collecting analytics with [Plausible](https://plausible.io/privacy-focused-web-analytics).

I've set the domain `food-system-digital-twin.vercel.app` in an environment variable. I'll merge this to see if it will work as expected in staging and later we can setup the production website.

cc @wrynearson